### PR TITLE
pull 

### DIFF
--- a/charts/cinder-csi-plugin/Chart.yaml
+++ b/charts/cinder-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Cinder CSI Chart for OpenStack
 name: openstack-cinder-csi
-version: 1.3.4
+version: 1.3.5
 home: https://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/cinder-csi-plugin/templates/_helpers.tpl
+++ b/charts/cinder-csi-plugin/templates/_helpers.tpl
@@ -88,3 +88,13 @@ component: nodeplugin
 {{ include "cinder-csi.nodeplugin.matchLabels" . }}
 {{ include "cinder-csi.common.metaLabels" . }}
 {{- end -}}
+
+{{- define "cinder-csi.snapshot-controller.matchLabels" -}}
+component: snapshot-controller
+{{ include "cinder-csi.common.matchLabels" . }}
+{{- end -}}
+
+{{- define "cinder-csi.snapshot-controller.labels" -}}
+{{ include "cinder-csi.snapshot-controller.matchLabels" . }}
+{{ include "cinder-csi.common.metaLabels" . }}
+{{- end -}}

--- a/charts/cinder-csi-plugin/templates/snapshot-controller-rbac.yaml
+++ b/charts/cinder-csi-plugin/templates/snapshot-controller-rbac.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.csi.snapshotController.enabled -}}
+# RBAC file for the snapshot controller.
+#
+# The snapshot controller implements the control loop for CSI snapshot functionality.
+# It should be installed as part of the base Kubernetes distribution in an appropriate
+# namespace for components implementing base system functionality. For installing with
+# Vanilla Kubernetes, kube-system makes sense for the namespace.
+# 
+# Enable this only if your Kubernetes distribution does not bundle the snapshot controller.
+# It should be installed only once per cluster, independent of CSI driver.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-controller
+  namespace: {{ .Release.Namespace }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-role
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-controller-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  # change the name also here if the ClusterRole gets renamed
+  name: snapshot-controller-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-leaderelection
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-controller-leaderelection
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: snapshot-controller-leaderelection
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/cinder-csi-plugin/templates/snapshot-controller-statefulset.yaml
+++ b/charts/cinder-csi-plugin/templates/snapshot-controller-statefulset.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.csi.snapshotController.enabled -}}
+# This YAML file shows how to deploy the snapshot controller
+
+# The snapshot controller implements the control loop for CSI snapshot functionality.
+# It should be installed as part of the base Kubernetes distribution in an appropriate
+# namespace for components implementing base system functionality. For installing with
+# Vanilla Kubernetes, kube-system makes sense for the namespace.
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  labels:
+    {{- include "cinder-csi.snapshot-controller.labels" . | nindent 4 }}
+  name: {{ include "cinder-csi.name" . }}-snapshot-controller
+spec:
+  serviceName: "snapshot-controller"
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "cinder-csi.snapshot-controller.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "cinder-csi.snapshot-controller.labels" . | nindent 8 }}
+    spec:
+      serviceAccount: snapshot-controller-sa
+      containers:
+        - name: snapshot-controller
+          image: "{{ .Values.csi.snapshotController.image.repository }}:{{ .Values.csi.snapshotController.image.tag }}"
+          args:
+            - "--leader-election=false"
+          imagePullPolicy: IfNotPresent
+{{- end }}

--- a/charts/cinder-csi-plugin/values.yaml
+++ b/charts/cinder-csi-plugin/values.yaml
@@ -54,6 +54,11 @@ csi:
       - name: cloud-config
         mountPath: /etc/kubernetes
         readOnly: true
+  snapshotController:
+    enabled: false
+    image:
+      repository: k8s.gcr.io/sig-storage/snapshot-controller
+      tag: v2.1.3
 
 secret:
   enabled: false

--- a/charts/manila-csi-plugin/Chart.yaml
+++ b/charts/manila-csi-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: latest
 description: Manila CSI Chart for OpenStack
 name: openstack-manila-csi
-version: 1.1.0
+version: 1.1.1
 home: http://github.com/kubernetes/cloud-provider-openstack
 icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
 maintainers:

--- a/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
+++ b/charts/manila-csi-plugin/templates/nodeplugin-daemonset.yaml
@@ -134,3 +134,6 @@ spec:
     {{- if .Values.nodeplugin.tolerations }}
       tolerations: {{ toYaml .Values.nodeplugin.tolerations | nindent 8 }}
     {{- end }}
+    {{- if .Values.nodeplugin.priorityClassName }}
+      priorityClassName: {{ .Values.nodeplugin.priorityClassName }}
+    {{- end }}

--- a/charts/manila-csi-plugin/values.yaml
+++ b/charts/manila-csi-plugin/values.yaml
@@ -54,6 +54,7 @@ nodeplugin:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  priorityClassName: ""
   # Use fullnameOverride to fully override the name of this component
   # fullnameOverride: some-other-name
 

--- a/cmd/manila-csi-plugin/main.go
+++ b/cmd/manila-csi-plugin/main.go
@@ -44,6 +44,7 @@ var (
 	fwdEndpoint           string
 	userAgentData         []string
 	compatibilitySettings string
+	clusterID             string
 )
 
 func validateShareProtocolSelector(v string) error {
@@ -140,6 +141,7 @@ func main() {
 					ManilaClientBuilder: manilaClientBuilder,
 					CSIClientBuilder:    csiClientBuilder,
 					CompatOpts:          compatOpts,
+					ClusterID:           clusterID,
 				},
 			)
 
@@ -177,6 +179,8 @@ func main() {
 	cmd.PersistentFlags().StringVar(&compatibilitySettings, "compatibility-settings", "", "settings for the compatibility layer")
 
 	cmd.PersistentFlags().StringArrayVar(&userAgentData, "user-agent", nil, "extra data to add to gophercloud user-agent. Use multiple times to add more than one component.")
+
+	cmd.PersistentFlags().StringVar(&clusterID, "cluster-id", "", "The identifier of the cluster that the plugin is running in.")
 
 	logs.InitLogs()
 	defer logs.FlushLogs()

--- a/docs/manila-csi-plugin/using-manila-csi-plugin.md
+++ b/docs/manila-csi-plugin/using-manila-csi-plugin.md
@@ -37,6 +37,7 @@ Option | Default value | Description
 `--with-topology` | _none_ | CSI Manila is topology-aware. See [Topology-aware dynamic provisioning](#topology-aware-dynamic-provisioning) for more info
 `--share-protocol-selector` | _none_ | Specifies which Manila share protocol to use for this instance of the driver. See [supported protocols](#share-protocol-support-matrix) for valid values.
 `--fwdendpoint` | _none_ | [CSI Node Plugin](https://github.com/container-storage-interface/spec/blob/master/spec.md#rpc-interface) endpoint to which all Node Service RPCs are forwarded. Must be able to handle the file-system specified in `share-protocol-selector`. Check out the [Deployment](#deployment) section to see why this is necessary.
+`--cluster-id` | _none_ | The identifier of the cluster that the plugin is running in. If set then the plugin will add "manila.csi.openstack.org/cluster: \<clusterID\>" to metadata of created shares.
 
 ### Controller Service volume parameters
 

--- a/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+++ b/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -28,7 +28,7 @@ External cloud providers were introduced as an Alpha feature in Kubernetes relea
 
 For more information about cloud-controller-manager, please see:
 
-- <https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20180530-cloud-controller-manager.md>
+- <https://github.com/kubernetes/enhancements/tree/master/keps/sig-cloud-provider/2392-cloud-controller-manager>
 - <https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager>
 - <https://kubernetes.io/docs/tasks/administer-cluster/developing-cloud-controller-manager/>
 

--- a/pkg/autohealing/cloudprovider/openstack/provider.go
+++ b/pkg/autohealing/cloudprovider/openstack/provider.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/startstop"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
@@ -60,12 +61,18 @@ var statusesPreventingRepair = sets.NewString(
 	stackStatusUpdateFailed,
 )
 
+// Cache the unhealthy nodes, if it's the first time we found this
+// unhealthy node, then we just reboot it and save it in this list. If it's not
+// the first time we found this unhealthy node, we will rebuild it.
+var unHealthyNodes = make(map[string]healthcheck.NodeInfo)
+
 // OpenStack is an implementation of cloud provider Interface for OpenStack.
 type OpenStackCloudProvider struct {
 	KubeClient           kubernetes.Interface
 	Nova                 *gophercloud.ServiceClient
 	Heat                 *gophercloud.ServiceClient
 	Magnum               *gophercloud.ServiceClient
+	Cinder               *gophercloud.ServiceClient
 	Config               config.Config
 	ResourceStackMapping map[string]ResourceStackRelationship
 }
@@ -184,23 +191,44 @@ func (provider OpenStackCloudProvider) waitForClusterComplete(clusterID string, 
 	return err
 }
 
-func (provider OpenStackCloudProvider) waitForServerDetachVolumes(serverID string, timeout time.Duration) error {
+// waitForServerDetachVolumes will detach all the attached volumes from the given
+// server with the timeout. And if there is a root volume of the server, the root
+// volume ID will be returned.
+func (provider OpenStackCloudProvider) waitForServerDetachVolumes(serverID string, timeout time.Duration) (string, error) {
+	rootVolumeID := ""
 	err := volumeattach.List(provider.Nova, serverID).EachPage(func(page pagination.Page) (bool, error) {
 		attachments, err := volumeattach.ExtractVolumeAttachments(page)
 		if err != nil {
 			return false, err
 		}
 		for _, attachment := range attachments {
-			log.Infof("detaching volume %s for instance %s", attachment.VolumeID, serverID)
-			err := volumeattach.Delete(provider.Nova, serverID, attachment.ID).ExtractErr()
+			volume, err := volumes.Get(provider.Cinder, attachment.VolumeID).Extract()
 			if err != nil {
-				return false, fmt.Errorf("failed to detach volume %s from instance %s", attachment.VolumeID, serverID)
+				return false, fmt.Errorf("failed to get volume %s, error: %s", attachment.VolumeID, err)
+			}
+
+			bootable, err := strconv.ParseBool(volume.Bootable)
+			if err != nil {
+				log.Warningf("Unexpected value for bootable volume %s in volume %s, error %s", volume.Bootable, volume, err)
+			}
+
+			log.Infof("volume %s is bootable %t", attachment.VolumeID, bootable)
+
+			if bootable == false {
+				log.Infof("detaching volume %s for instance %s", attachment.VolumeID, serverID)
+				err := volumeattach.Delete(provider.Nova, serverID, attachment.ID).ExtractErr()
+				if err != nil {
+					return false, fmt.Errorf("failed to detach volume %s from instance %s, error: %s", attachment.VolumeID, serverID, err)
+				}
+			} else {
+				rootVolumeID = attachment.VolumeID
+				log.Infof("the root volume for server %s is %s", serverID, attachment.VolumeID)
 			}
 		}
 		return true, err
 	})
 	if err != nil {
-		return err
+		return rootVolumeID, err
 	}
 	err = wait.Poll(3*time.Second, timeout,
 		func() (bool, error) {
@@ -209,20 +237,26 @@ func (provider OpenStackCloudProvider) waitForServerDetachVolumes(serverID strin
 				return false, err
 			}
 
-			if len(server.AttachedVolumes) == 0 {
+			if len(server.AttachedVolumes) == 0 && rootVolumeID == "" {
+				return true, nil
+			} else if len(server.AttachedVolumes) == 1 && rootVolumeID != "" {
+				// Root volume is left
 				return true, nil
 			}
 
 			return false, nil
 		})
 
-	return err
+	return rootVolumeID, err
 }
 
-// For master nodes: Soft deletes the VMs, marks the heat resource "unhealthy" then trigger Heat stack update in order to rebuild
-// the VMs. The information this function needs:
-//     - Nova VM IDs
-// 	   - Heat stack ID and resource ID.
+// Repair  For master nodes: detach etcd and docker volumes, find the root
+//         volume, then shutdown the VM, marks the both the VM and the root
+//         volume (heat resource) as "unhealthy" then trigger Heat stack update
+//         in order to rebuild the node. The information this function needs:
+//         - Nova VM ID
+//         - Root volume ID
+// 	       - Heat stack ID and resource ID.
 // For worker nodes: Call Magnum resize API directly.
 func (provider OpenStackCloudProvider) Repair(nodes []healthcheck.NodeInfo) error {
 	if len(nodes) == 0 {
@@ -234,6 +268,7 @@ func (provider OpenStackCloudProvider) Repair(nodes []healthcheck.NodeInfo) erro
 
 	clusterName := provider.Config.ClusterName
 	isWorkerNode := nodes[0].IsWorker
+	log.Infof("the node type to be repaired is worker node: %t", isWorkerNode)
 	if isWorkerNode {
 		workers = nodes
 	} else {
@@ -242,7 +277,7 @@ func (provider OpenStackCloudProvider) Repair(nodes []healthcheck.NodeInfo) erro
 
 	err := provider.UpdateHealthStatus(masters, workers)
 	if err != nil {
-		return fmt.Errorf("Failed to update the helath status of cluster %s, error: %v", clusterName, err)
+		return fmt.Errorf("failed to update the helath status of cluster %s, error: %v", clusterName, err)
 	}
 
 	cluster, err := clusters.Get(provider.Magnum, clusterName).Extract()
@@ -260,7 +295,25 @@ func (provider OpenStackCloudProvider) Repair(nodes []healthcheck.NodeInfo) erro
 			}
 			serverID := machineID.String()
 
-			if err := provider.waitForServerDetachVolumes(serverID, 30*time.Second); err != nil {
+			var firsttimeUnhealthy = true
+			for id := range unHealthyNodes {
+				log.V(5).Infof("comparing server ID %s with known broken ID %s", serverID, id)
+				if id == serverID {
+					firsttimeUnhealthy = false
+					break
+				}
+			}
+
+			if firsttimeUnhealthy == true {
+				unHealthyNodes[serverID] = n
+				log.Infof("rebooting node %s to repair it", serverID)
+				if res := servers.Reboot(provider.Nova, serverID, servers.RebootOpts{Type: servers.SoftReboot}); res.Err != nil {
+					log.Warningf("failed to reboot node %s, error: %v", serverID, res.Err)
+				}
+				continue
+			}
+
+			if _, err := provider.waitForServerDetachVolumes(serverID, 30*time.Second); err != nil {
 				log.Warningf("Failed to detach volumes from server %s, error: %v", serverID, err)
 			}
 
@@ -292,6 +345,7 @@ func (provider OpenStackCloudProvider) Repair(nodes []healthcheck.NodeInfo) erro
 			//	return fmt.Errorf("failed to resize cluster %s, error: %v", clusterName, ret.Err)
 			//}
 
+			delete(unHealthyNodes, serverID)
 			log.Infof("Cluster %s resized", clusterName)
 		}
 	} else {
@@ -307,13 +361,48 @@ func (provider OpenStackCloudProvider) Repair(nodes []healthcheck.NodeInfo) erro
 			return fmt.Errorf("failed to get the resource stack mapping for cluster %s, error: %v", clusterName, err)
 		}
 
+		opts := stackresources.MarkUnhealthyOpts{
+			MarkUnhealthy:        true,
+			ResourceStatusReason: "Mark resource unhealthy by autohealing service",
+		}
+
 		for _, n := range nodes {
-			id := uuid.Parse(n.KubeNode.Status.NodeInfo.MachineID)
-			if id == nil {
+			machineID := uuid.Parse(n.KubeNode.Status.NodeInfo.MachineID)
+			if machineID == nil {
 				log.Warningf("Failed to get the correct server ID for server %s", n.KubeNode.Name)
 				continue
 			}
-			serverID := id.String()
+			serverID := machineID.String()
+
+			var firsttimeUnhealthy = true
+			for id := range unHealthyNodes {
+				log.Infof("comparing server ID %s with known broken ID %s", serverID, id)
+				if id == serverID {
+					firsttimeUnhealthy = false
+					break
+				}
+			}
+
+			if firsttimeUnhealthy == true {
+				unHealthyNodes[serverID] = n
+				log.Infof("rebooting node %s to repair it", serverID)
+				if res := servers.Reboot(provider.Nova, serverID, servers.RebootOpts{Type: servers.SoftReboot}); res.Err != nil {
+					log.Warningf("failed to reboot node %s, error: %v", serverID, res.Err)
+				}
+				continue
+			}
+
+			if rootVolumeID, err := provider.waitForServerDetachVolumes(serverID, 30*time.Second); err != nil {
+				log.Warningf("Failed to detach volumes from server %s, error: %v", serverID, err)
+			} else {
+				// Mark root volume as unhealthy
+				if rootVolumeID != "" {
+					err = stackresources.MarkUnhealthy(provider.Heat, allMapping[serverID].StackName, allMapping[serverID].StackID, rootVolumeID, opts).ExtractErr()
+					if err != nil {
+						log.Errorf("failed to mark resource %s unhealthy, error: %v", rootVolumeID, err)
+					}
+				}
+			}
 
 			if err := provider.waitForServerPoweredOff(serverID, 30*time.Second); err != nil {
 				log.Warningf("Failed to shutdown the server %s, error: %v", serverID, err)
@@ -321,14 +410,13 @@ func (provider OpenStackCloudProvider) Repair(nodes []healthcheck.NodeInfo) erro
 
 			log.Infof("Marking Nova VM %s(Heat resource %s) unhealthy for Heat stack %s", serverID, allMapping[serverID].ResourceID, cluster.StackID)
 
-			opts := stackresources.MarkUnhealthyOpts{
-				MarkUnhealthy:        true,
-				ResourceStatusReason: "Mark resource unhealthy by autohealing service",
-			}
+			// Mark VM as unhealthy
 			err = stackresources.MarkUnhealthy(provider.Heat, allMapping[serverID].StackName, allMapping[serverID].StackID, allMapping[serverID].ResourceID, opts).ExtractErr()
 			if err != nil {
 				log.Errorf("failed to mark resource %s unhealthy, error: %v", serverID, err)
 			}
+
+			delete(unHealthyNodes, serverID)
 		}
 
 		if err := stacks.UpdatePatch(provider.Heat, clusterStackName, cluster.StackID, stacks.UpdateOpts{}).ExtractErr(); err != nil {

--- a/pkg/autohealing/cloudprovider/register/register.go
+++ b/pkg/autohealing/cloudprovider/register/register.go
@@ -63,12 +63,20 @@ func registerOpenStack(cfg config.Config, kubeClient kubernetes.Interface) (clou
 	}
 	magnumClient.Microversion = "latest"
 
+	// get cinder service client
+	var cinderClient *gophercloud.ServiceClient
+	cinderClient, err = gopenstack.NewBlockStorageV2(client, eoOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find Cinder service endpoint in the region %s: %v", cfg.OpenStack.Region, err)
+	}
+
 	var p cloudprovider.CloudProvider
 	p = openstack.OpenStackCloudProvider{
 		KubeClient: kubeClient,
 		Nova:       novaClient,
 		Heat:       heatClient,
 		Magnum:     magnumClient,
+		Cinder:     cinderClient,
 		Config:     cfg,
 	}
 

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 	ossnapshots "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
+	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -41,7 +42,7 @@ type controllerServer struct {
 }
 
 func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
-	klog.V(4).Infof("CreateVolume: called with args %+v", *req)
+	klog.V(4).Infof("CreateVolume: called with args %+v", protosanitizer.StripSecrets(*req))
 
 	// Volume Name
 	volName := req.GetName()
@@ -142,7 +143,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 }
 
 func (cs *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
-	klog.V(4).Infof("DeleteVolume: called with args %+v", *req)
+	klog.V(4).Infof("DeleteVolume: called with args %+v", protosanitizer.StripSecrets(*req))
 
 	// Volume Delete
 	volID := req.GetVolumeId()
@@ -537,7 +538,7 @@ func (cs *controllerServer) ControllerGetVolume(context.Context, *csi.Controller
 }
 
 func (cs *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
-	klog.V(4).Infof("ControllerExpandVolume: called with args %+v", *req)
+	klog.V(4).Infof("ControllerExpandVolume: called with args %+v", protosanitizer.StripSecrets(*req))
 
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {

--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -67,7 +67,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	ephemeralVolume := req.GetVolumeContext()["csi.storage.k8s.io/ephemeral"] == "true"
 	if ephemeralVolume {
-		return nodePublishEphermeral(req, ns)
+		return nodePublishEphemeral(req, ns)
 	}
 
 	// In case of ephemeral volume staging path not provided
@@ -118,7 +118,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
-func nodePublishEphermeral(req *csi.NodePublishVolumeRequest, ns *nodeServer) (*csi.NodePublishVolumeResponse, error) {
+func nodePublishEphemeral(req *csi.NodePublishVolumeRequest, ns *nodeServer) (*csi.NodePublishVolumeResponse, error) {
 
 	var size int
 	var err error
@@ -152,8 +152,8 @@ func nodePublishEphermeral(req *csi.NodePublishVolumeRequest, ns *nodeServer) (*
 	evol, err := ns.Cloud.CreateVolume(volName, size, volumeType, volAvailability, "", "", &properties)
 
 	if err != nil {
-		klog.V(3).Infof("Failed to Create Ephermal Volume: %v", err)
-		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to create Ephermal Volume %v", err))
+		klog.V(3).Infof("Failed to Create Ephemeral Volume: %v", err)
+		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to create Ephemeral Volume %v", err))
 	}
 
 	// Wait for volume status to be Available, before attaching
@@ -165,7 +165,7 @@ func nodePublishEphermeral(req *csi.NodePublishVolumeRequest, ns *nodeServer) (*
 		}
 	}
 
-	klog.V(4).Infof("Ephermeral Volume %s is created", evol.ID)
+	klog.V(4).Infof("Ephemeral Volume %s is created", evol.ID)
 
 	// attach volume
 	// for attach volume we need to have information about node.
@@ -310,14 +310,14 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	}
 
 	if ephemeralVolume {
-		return nodeUnpublishEphermeral(req, ns, vol)
+		return nodeUnpublishEphemeral(req, ns, vol)
 	}
 
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 
 }
 
-func nodeUnpublishEphermeral(req *csi.NodeUnpublishVolumeRequest, ns *nodeServer, vol *volumes.Volume) (*csi.NodeUnpublishVolumeResponse, error) {
+func nodeUnpublishEphemeral(req *csi.NodeUnpublishVolumeRequest, ns *nodeServer, vol *volumes.Volume) (*csi.NodeUnpublishVolumeResponse, error) {
 	volumeID := vol.ID
 	var instanceID string
 

--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
+	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -47,7 +48,7 @@ type nodeServer struct {
 }
 
 func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
-	klog.V(4).Infof("NodePublishVolume: called with args %+v", *req)
+	klog.V(4).Infof("NodePublishVolume: called with args %+v", protosanitizer.StripSecrets(*req))
 
 	volumeID := req.GetVolumeId()
 	source := req.GetStagingTargetPath()
@@ -226,7 +227,7 @@ func nodePublishEphermeral(req *csi.NodePublishVolumeRequest, ns *nodeServer) (*
 }
 
 func nodePublishVolumeForBlock(req *csi.NodePublishVolumeRequest, ns *nodeServer, mountOptions []string) (*csi.NodePublishVolumeResponse, error) {
-	klog.V(4).Infof("NodePublishVolumeBlock: called with args %+v", *req)
+	klog.V(4).Infof("NodePublishVolumeBlock: called with args %+v", protosanitizer.StripSecrets(*req))
 
 	volumeID := req.GetVolumeId()
 	targetPath := req.GetTargetPath()
@@ -265,7 +266,7 @@ func nodePublishVolumeForBlock(req *csi.NodePublishVolumeRequest, ns *nodeServer
 }
 
 func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
-	klog.V(4).Infof("NodeUnPublishVolume: called with args %+v", *req)
+	klog.V(4).Infof("NodeUnPublishVolume: called with args %+v", protosanitizer.StripSecrets(*req))
 
 	volumeID := req.GetVolumeId()
 	targetPath := req.GetTargetPath()
@@ -348,7 +349,7 @@ func nodeUnpublishEphermeral(req *csi.NodeUnpublishVolumeRequest, ns *nodeServer
 }
 
 func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
-	klog.V(4).Infof("NodeStageVolume: called with args %+v", *req)
+	klog.V(4).Infof("NodeStageVolume: called with args %+v", protosanitizer.StripSecrets(*req))
 
 	stagingTarget := req.GetStagingTargetPath()
 	volumeCapability := req.GetVolumeCapability()
@@ -414,7 +415,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 }
 
 func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
-	klog.V(4).Infof("NodeUnstageVolume: called with args %+v", *req)
+	klog.V(4).Infof("NodeUnstageVolume: called with args %+v", protosanitizer.StripSecrets(*req))
 
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -474,7 +475,7 @@ func (ns *nodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetC
 }
 
 func (ns *nodeServer) NodeGetVolumeStats(_ context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
-	klog.V(4).Infof("NodeGetVolumeStats: called with args %+v", *req)
+	klog.V(4).Infof("NodeGetVolumeStats: called with args %+v", protosanitizer.StripSecrets(*req))
 
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -518,7 +519,7 @@ func (ns *nodeServer) NodeGetVolumeStats(_ context.Context, req *csi.NodeGetVolu
 }
 
 func (ns *nodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
-	klog.V(4).Infof("NodeExpandVolume: called with args %+v", *req)
+	klog.V(4).Infof("NodeExpandVolume: called with args %+v", protosanitizer.StripSecrets(*req))
 
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {

--- a/pkg/csi/cinder/utils.go
+++ b/pkg/csi/cinder/utils.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"k8s.io/cloud-provider-openstack/pkg/csi/cinder/openstack"
@@ -78,12 +79,12 @@ func ParseEndpoint(ep string) (string, string, error) {
 
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	klog.V(3).Infof("GRPC call: %s", info.FullMethod)
-	klog.V(5).Infof("GRPC request: %+v", req)
+	klog.V(5).Infof("GRPC request: %+v", protosanitizer.StripSecrets(req))
 	resp, err := handler(ctx, req)
 	if err != nil {
 		klog.Errorf("GRPC error: %v", err)
 	} else {
-		klog.V(5).Infof("GRPC response: %+v", resp)
+		klog.V(5).Infof("GRPC response: %+v", protosanitizer.StripSecrets(resp))
 	}
 	return resp, err
 }

--- a/pkg/csi/manila/controllerserver.go
+++ b/pkg/csi/manila/controllerserver.go
@@ -18,6 +18,7 @@ package manila
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"sync"
 
@@ -32,6 +33,8 @@ import (
 	clouderrors "k8s.io/cloud-provider-openstack/pkg/util/errors"
 	"k8s.io/klog/v2"
 )
+
+const clusterMetadataKey = "manila.csi.openstack.org/cluster"
 
 type controllerServer struct {
 	d *Driver
@@ -82,6 +85,11 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, status.Errorf(codes.InvalidArgument, "invalid volume parameters: %v", err)
 	}
 
+	shareMetadata, err := prepareShareMetadata(shareOpts.AppendShareMetadata, cs.d.clusterID)
+	if err != nil {
+		return nil, err
+	}
+
 	osOpts, err := options.NewOpenstackOptions(req.GetSecrets())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid OpenStack secrets: %v", err)
@@ -118,7 +126,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, err
 	}
 
-	share, err := volCreator.create(req, req.GetName(), sizeInGiB, manilaClient, shareOpts)
+	share, err := volCreator.create(req, req.GetName(), sizeInGiB, manilaClient, shareOpts, shareMetadata)
 	if err != nil {
 		return nil, err
 	}
@@ -421,4 +429,33 @@ func (cs *controllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 
 func (cs *controllerServer) ControllerGetVolume(context.Context, *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
+}
+
+func parseStringMapFromJson(data string) (m map[string]string, err error) {
+	if data == "" {
+		return
+	}
+
+	err = json.Unmarshal([]byte(data), &m)
+	return
+}
+
+func prepareShareMetadata(appendShareMetadata, clusterID string) (map[string]string, error) {
+	shareMetadata, err := parseStringMapFromJson(appendShareMetadata)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to parse appendShareMetadata field: %v", err)
+	}
+
+	if clusterID != "" {
+		if shareMetadata == nil {
+			shareMetadata = make(map[string]string)
+		}
+		if val, ok := shareMetadata[clusterMetadataKey]; ok && val != clusterID {
+			klog.Warningf("skip adding cluster ID %v to share metadata because appended metadata already defines it as %v", clusterID, val)
+		} else {
+			shareMetadata[clusterMetadataKey] = clusterID
+		}
+	}
+
+	return shareMetadata, nil
 }

--- a/pkg/csi/manila/controllerserver_test.go
+++ b/pkg/csi/manila/controllerserver_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manila
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPrepareShareMetadata(t *testing.T) {
+	ts := []struct {
+		appendShareMetadata string
+		cluster             string
+		expectedResult      map[string]string
+		expectedError       bool
+	}{
+		{
+			// Empty metadata and cluster
+			appendShareMetadata: "",
+			cluster:             "",
+			expectedResult:      nil,
+			expectedError:       false,
+		},
+		{
+			// Existing metadata and empty cluster
+			appendShareMetadata: "{\"keyA\": \"valueA\", \"keyB\": \"valueB\"}",
+			cluster:             "",
+			expectedResult:      map[string]string{"keyA": "valueA", "keyB": "valueB"},
+			expectedError:       false,
+		},
+		{
+			// Just cluster and no metadata
+			appendShareMetadata: "",
+			cluster:             "MyCluster",
+			expectedResult:      map[string]string{clusterMetadataKey: "MyCluster"},
+			expectedError:       false,
+		},
+		{
+			// Both metadata and cluster
+			appendShareMetadata: "{\"keyA\": \"valueA\", \"keyB\": \"valueB\"}",
+			cluster:             "MyCluster",
+			expectedResult:      map[string]string{"keyA": "valueA", "keyB": "valueB", clusterMetadataKey: "MyCluster"},
+			expectedError:       false,
+		},
+		{
+			// Overwrite cluster
+			appendShareMetadata: "{\"keyA\": \"valueA\", \"" + clusterMetadataKey + "\": \"SomeValue\"}",
+			cluster:             "MyCluster",
+			expectedResult:      map[string]string{"keyA": "valueA", clusterMetadataKey: "SomeValue"},
+			expectedError:       false,
+		},
+		{
+			// Incorrect metadata
+			appendShareMetadata: "INVALID",
+			cluster:             "MyCluster",
+			expectedResult:      nil,
+			expectedError:       true,
+		},
+	}
+
+	for i := range ts {
+		result, err := prepareShareMetadata(ts[i].appendShareMetadata, ts[i].cluster)
+
+		if err != nil && !ts[i].expectedError {
+			t.Errorf("test %d: unexpected error: %v", i, err)
+		}
+
+		if fmt.Sprint(result) != fmt.Sprint(ts[i].expectedResult) {
+			t.Errorf("test %d: returned an incorrect result: got %#v, expected %#v", i, result, ts[i].expectedResult)
+		}
+	}
+}

--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -247,6 +247,7 @@ func (d *Driver) initProxiedDriver() (csiNodeCapabilitySet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("connecting to %s endpoint failed: %v", d.fwdEndpoint, err)
 	}
+	defer conn.Close()
 
 	identityClient := d.csiClientBuilder.NewIdentityServiceClient(conn)
 

--- a/pkg/csi/manila/driver.go
+++ b/pkg/csi/manila/driver.go
@@ -42,6 +42,7 @@ type DriverOpts struct {
 	NodeAZ       string
 	WithTopology bool
 	ShareProto   string
+	ClusterID    string
 
 	ServerCSIEndpoint string
 	FwdCSIEndpoint    string
@@ -59,6 +60,7 @@ type Driver struct {
 	name         string
 	fqVersion    string // Fully qualified version in format {driverVersion}@{CPO version}
 	shareProto   string
+	clusterID    string
 
 	serverEndpoint string
 	fwdEndpoint    string
@@ -119,6 +121,7 @@ func NewDriver(o *DriverOpts) (*Driver, error) {
 		compatOpts:          o.CompatOpts,
 		manilaClientBuilder: o.ManilaClientBuilder,
 		csiClientBuilder:    o.CSIClientBuilder,
+		clusterID:           o.ClusterID,
 	}
 
 	klog.Info("Driver: ", d.name)

--- a/pkg/csi/manila/identityserver.go
+++ b/pkg/csi/manila/identityserver.go
@@ -43,6 +43,7 @@ func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*c
 	if err != nil {
 		return nil, status.Error(codes.FailedPrecondition, fmtGrpcConnError(ids.d.fwdEndpoint, err))
 	}
+	defer csiConn.Close()
 
 	return ids.d.csiClientBuilder.NewIdentityServiceClient(csiConn).Probe(ctx, req)
 }

--- a/pkg/csi/manila/nodeserver.go
+++ b/pkg/csi/manila/nodeserver.go
@@ -211,6 +211,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
 	}
+	defer csiConn.Close()
 
 	req.Secrets = secret
 	req.VolumeContext = volumeCtx
@@ -227,6 +228,7 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
 	}
+	defer csiConn.Close()
 
 	return ns.d.csiClientBuilder.NewNodeServiceClient(csiConn).UnpublishVolume(ctx, req)
 }
@@ -285,6 +287,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
 	}
+	defer csiConn.Close()
 
 	req.Secrets = stageSecret
 	req.VolumeContext = volumeCtx
@@ -305,6 +308,7 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	if err != nil {
 		return nil, status.Error(codes.Unavailable, fmtGrpcConnError(ns.d.fwdEndpoint, err))
 	}
+	defer csiConn.Close()
 
 	return ns.d.csiClientBuilder.NewNodeServiceClient(csiConn).UnstageVolume(ctx, req)
 }

--- a/tests/e2e/csi/cinder/cinder-testdriver.go
+++ b/tests/e2e/csi/cinder/cinder-testdriver.go
@@ -50,8 +50,8 @@ func initCinderDriver(name string, manifests ...string) testsuites.TestDriver {
 				testsuites.CapMultiPODs:          true,
 				testsuites.CapBlock:              true,
 				testsuites.CapSnapshotDataSource: true,
-				testsuites.CapPVCDataSource:      true,
-				testsuites.CapTopology:           true,
+				//testsuites.CapPVCDataSource:      true,
+				testsuites.CapTopology: true,
 			},
 			TopologyKeys: []string{
 				"topology.cinder.csi.openstack.org/zone",

--- a/tests/sanity/manila/fakecsiclient.go
+++ b/tests/sanity/manila/fakecsiclient.go
@@ -80,10 +80,12 @@ func (c fakeNodeSvcClient) UnpublishVolume(context.Context, *csi.NodeUnpublishVo
 
 type fakeCSIClientBuilder struct{}
 
-func (b fakeCSIClientBuilder) NewConnection(string) (*grpc.ClientConn, error) { return nil, nil }
+func (b fakeCSIClientBuilder) NewConnection(string) (*grpc.ClientConn, error) {
+	return grpc.Dial("", grpc.WithInsecure())
+}
 
 func (b fakeCSIClientBuilder) NewConnectionWithContext(context.Context, string) (*grpc.ClientConn, error) {
-	return nil, nil
+	return grpc.Dial("", grpc.WithInsecure())
 }
 
 func (b fakeCSIClientBuilder) NewNodeServiceClient(conn *grpc.ClientConn) csiclient.Node {


### PR DESCRIPTION
<!--
Please add the affected binary name in the title unless multiple binaries are affected, e.g.
[cinder-csi-plugin] Fix volume deletion
For openstack-cloud-controller-manager, you can use [occm] for short.

All the currently maintained binaries are:
* openstack-cloud-controller-manager (occm)
* cinder-csi-plugin
* manila-csi-plugin
* k8s-keystone-auth
* client-keystone-auth
* octavia-ingress-controller
* magnum-auto-healer
* barbican-kms-plugin
-->

**What this PR does / why we need it**:

**Which issue this PR fixes(if applicable)**:
fixes #

**Special notes for reviewers**:
<!-- e.g. How to test this PR -->

**Release note**:
<!--
1. Release note is required if a significant change is introduced, otherwise please keep this section as is.
2. Release note is in Markdown format and should begin with the binary name unless multiple binaries are affected, e.g. [openstack-cloud-controller-manager] Deprecate Neutron-LBaaS support.
3. Instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
update
```
